### PR TITLE
Asset not found

### DIFF
--- a/iNCIPit.cgi
+++ b/iNCIPit.cgi
@@ -1412,7 +1412,11 @@ sub copy_from_barcode {
       OpenSRF::AppSession->create('open-ils.search')
       ->request( 'open-ils.search.asset.copy.find_by_barcode', $barcode )
       ->gather(1);
-    return $response;
+    if (ref($response) eq 'HASH') {
+        return undef;
+    } else {
+        return $response;
+    }
 }
 
 sub locid_from_barcode {

--- a/iNCIPit.cgi
+++ b/iNCIPit.cgi
@@ -511,6 +511,13 @@ sub item_cancelled {
         # we are the user agency
         $barcode .= $faidValue;
         my $copy = copy_from_barcode($barcode);
+        if (ref($copy) eq "HASH") {
+            if ($copy->{textcode} eq 'ASSET_COPY_NOT_FOUND') {
+            staff_log( $taidValue, $faidValue, "Bad Barcode Requested: ". $barcode );
+            fail("cancel request on non-existent item");
+            exit;
+            }
+        }
         fail( $copy->{textcode} . " $barcode" ) unless ( blessed $copy);
         my $r = cancel_hold($barcode);
         $r = delete_copy($copy);
@@ -1412,11 +1419,7 @@ sub copy_from_barcode {
       OpenSRF::AppSession->create('open-ils.search')
       ->request( 'open-ils.search.asset.copy.find_by_barcode', $barcode )
       ->gather(1);
-    if (ref($response) eq 'HASH') {
-        return undef;
-    } else {
-        return $response;
-    }
+    return $response;
 }
 
 sub locid_from_barcode {

--- a/iNCIPit.cgi
+++ b/iNCIPit.cgi
@@ -517,10 +517,19 @@ sub item_cancelled {
     } else {
         # we are the item agency
         unless ( $conf->{behavior}->{no_item_agency_holds} =~ m/^y/i ) {
+            # Make sure the copy exists!
+            my $copy = copy_from_barcode($barcode);
+            # If copy does not exist, return failure
+            if (ref($copy) eq "HASH") {
+              if ($copy->{textcode} eq 'ASSET_COPY_NOT_FOUND') {
+                staff_log( $taidValue, $faidValue, "Bad Barcode Requested: ". $barcode );
+                fail("cancel request on non-existent item");
+                exit;
+              }
+            }
             # remove hold!
             my $r = cancel_hold($barcode);
-            # TODO: check for any errors or unexpected return values in $r
-            my $copy = copy_from_barcode($barcode);
+
             fail( $copy->{textcode} . " $barcode" ) unless ( blessed $copy);
             $r = update_copy( $copy, 7 ); # set to reshelving (for wiggle room)
             # TODO: check for any errors or unexpected return values in $r


### PR DESCRIPTION
Mostly based of GRPL code:

- Makes sure hold is cancelled before deleting the copy
- Does check and logging in both places when asset copy isn't found.

This can be later simplified to just being in the copy_from_barcode but there isn't as much info accessible there to log right now.

Need to test the cgi in production and see if it handles these cases well. Probably should do a rebase commit to make this a single if it does.